### PR TITLE
fix: != operator of Entity to properly handle comparison with null

### DIFF
--- a/src/Entity.cs
+++ b/src/Entity.cs
@@ -185,5 +185,5 @@ public class Entity
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(Entity left, Entity right) => left is not null && left.Equals(right);
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator !=(Entity left, Entity right) => left is null || !left.Equals(right);
+    public static bool operator !=(Entity left, Entity right) => (left is null && right is not null) || (left is not null && !left.Equals(right));
 }


### PR DESCRIPTION
The !=  operator of `Entity` doesn't properly compare to null, e.g. 

```csharp
Entity foo = null;

if (foo != null) { 
  // succeeds.
}

```

This patch should fix this.