### PR TITLE
fix: don't try to add/remove components of despawned entities

### DIFF
--- a/src/World.cs
+++ b/src/World.cs
@@ -447,8 +447,12 @@ public sealed class World
             var op = tableOperations[i];
 
             if (op.Despawn) Despawn(op.Identity);
-            else if (op.Add && IsAlive(op.Identity)) AddComponent(op.Type, op.Identity, op.Data);
-            else if (IsAlive(op.Identity)) RemoveComponent(op.Type, op.Identity);
+            // only try other operations if the entity is still alive at this point
+            else if (IsAlive(op.Identity))
+            {
+                if (op.Add) AddComponent(op.Type, op.Identity, op.Data);
+                else RemoveComponent(op.Type, op.Identity);
+            }
 
             tableOperations.RemoveAt(i);
         }

--- a/src/World.cs
+++ b/src/World.cs
@@ -447,8 +447,8 @@ public sealed class World
             var op = tableOperations[i];
 
             if (op.Despawn) Despawn(op.Identity);
-            else if (op.Add) AddComponent(op.Type, op.Identity, op.Data);
-            else RemoveComponent(op.Type, op.Identity);
+            else if (op.Add && IsAlive(op.Identity)) AddComponent(op.Type, op.Identity, op.Data);
+            else if (IsAlive(op.Identity)) RemoveComponent(op.Type, op.Identity);
 
             tableOperations.RemoveAt(i);
         }


### PR DESCRIPTION
suppose you have some component `FooComponent` and `BarComponent`  and you have a system like this:

```csharp
foreach(var (entity, foo) in commands.Query<Entity,FooComponent>()) {
    if (entity.Has<BarComponent>()) { 
          entity.Remove<BarComponent>();
    }
    
    if (foo.IsFooTastic) {
         entity.Despawn();
    }
}
```

What now happens is both the remove and the despawn operation will be enqueued because for the duration of the enumeration the table where the entity is located is locked. When the enumerator is disposed the queued operations will be executed in reverse, so the despawn operation is first. This will remove the entity from the table. Next the remove operation runs, but it runs on an entity that is no longer alive.

There is probably a reason why these operations are executed in reverse so I kept this. Also just changing execution order would break as well if the despawn came first and the remove came later. So I chose to add a check to `ApplyTableOperations`  to ensure that both adding and removing of components is only attempted if the entity is alive at this point in time.