### PR TITLE
Global Lock

### DIFF
--- a/src/Query.cs
+++ b/src/Query.cs
@@ -38,13 +38,9 @@ public class Enumerator : IEnumerator, IDisposable
     protected Enumerator(World world, List<Table> tables)
     {
         this.world = world;
-        
         Tables = tables;
         
-        foreach (var table in tables)
-        {
-            table.Lock();
-        }
+        world.Lock();
         
         Reset();
     }
@@ -87,12 +83,7 @@ public class Enumerator : IEnumerator, IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Dispose()
     {
-        foreach (var table in Tables)
-        {
-            table.Unlock();
-        }
-        
-        world.ApplyTableOperations();
+        world.Unlock();
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -23,11 +23,8 @@ public sealed class Table
     
     public int Count { get; private set; }
     public bool IsEmpty => Count == 0;
-    public bool IsLocked { get; private set; }
     
     readonly World world;
-    
-    int lockCount;
 
     Identity[] entities;
     readonly Array[] storages;
@@ -165,22 +162,5 @@ public sealed class Table
         oldTable.Remove(oldRow);
 
         return newRow;
-    }
-    
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Lock()
-    {
-        lockCount++;
-        IsLocked = true;
-    }
-    
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Unlock()
-    {
-        lockCount--;
-        if (lockCount == 0)
-        {
-            IsLocked = false;
-        }
     }
 }

--- a/src/World.cs
+++ b/src/World.cs
@@ -450,17 +450,13 @@ public sealed class World
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     void ApplyTableOperations()
     {
-        if (isLocked) return;
-
         foreach (var op in tableOperations)
         {
+            if (!IsAlive(op.Identity)) continue;
+            
             if (op.Despawn) Despawn(op.Identity);
-            // only try other operations if the entity is still alive at this point
-            else if (IsAlive(op.Identity))
-            {
-                if (op.Add) AddComponent(op.Type, op.Identity, op.Data);
-                else RemoveComponent(op.Type, op.Identity);
-            }
+            else if (op.Add) AddComponent(op.Type, op.Identity, op.Data);
+            else RemoveComponent(op.Type, op.Identity);
         }
 
         tableOperations.Clear();
@@ -477,10 +473,9 @@ public sealed class World
     public void Unlock()
     {
         lockCount--;
-
         if (lockCount != 0) return;
-
         isLocked = false;
+        
         ApplyTableOperations();
     }
 


### PR DESCRIPTION
There are currently some edge case bugs when doing table operations within nested query loops.
this global lock should fix those edge cases.
This means that any operations that are happening within a query loop / nested loop will delay until no iteration is active anymore.